### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The [PubNub class](./PubNub.class.nut) wraps [PubNub’s API](http://www.pubnub.
 
 The [MessageBus class](./MessageBus) uses the PubNub API to create seamless device to device communication (through their agents and PubNub).
 
+[![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/PubNub/functions?utm_source=PubnubGithub&utm_medium=button&utm_content=Vender_GitHub)
+
 ## Contributors
 
 - Matt Haines


### PR DESCRIPTION
Hey there. I added a link in your README to a tool where you can test out PubNub API calls in your browser before using your SDK to connect to the API. I've added it to these other SDKs (Telegram, Shopify and LinkedIn) and gotten feedback that it was pretty useful. If anything, let me know what you think and if you have any feedback. I'm part of the team that built this tool and we're always looking to make it better!